### PR TITLE
Fix typos.

### DIFF
--- a/content/_guides/first_start.md
+++ b/content/_guides/first_start.md
@@ -37,7 +37,7 @@ Enter the address and port in the textbox. For example: `node.community.rino.io:
 
 ### Connecting to a local node
 
-Feather automatically detects the presense of a [local node](local-node) on the default port.
+Feather automatically detects the presence of a [local node](local-node) on the default port.
 
 Feather does not manage a local node for you. 
 If you want to run a local node, follow the steps in [this guide](https://moneroguides.org/tutorials/01x02-setting-up-your-own-node/) to set one up.

--- a/content/_guides/nodes.md
+++ b/content/_guides/nodes.md
@@ -53,7 +53,7 @@ During normal use the wallet will use the following endpoints:
 |/get_transaction_pool_hashes.bin| Sync | Get tx hashes from transaction pool. Called every 10 seconds after main sync is finished. |
 |/get_transactions| Sync | Get pool transactions the wallet hasn't scanned before. |
 |/get_output_distribution| Tx Construction | Output distribution used in decoy selection. Data is hashed and checked against a hardcoded value to mitigate against output distribution poisoning.<br>In Feather, the distribution is requested and cached immediately upon finishing wallet synchronization to cut bandwidth requirements for transaction construction by an order of magnitude. |
-|/get_outs.bin| Tx Construction | Request output public keys for selected indeces of ring members. The wallet cannot verify the validity of the public keys, except for the true input. Feather will show a warning if the true input is missing from the reponse. |
+|/get_outs.bin| Tx Construction | Request output public keys for selected indeces of ring members. The wallet cannot verify the validity of the public keys, except for the true input. Feather will show a warning if the true input is missing from the response. |
 |get_fee_estimate| Tx Construction | Get base transaction fee. Malicious nodes can introduce a fungibility defect by providing an incorrect fee estimate. |
 |hard_fork_info | Tx Construction | Get information about hard fork state. |
 |/send_raw_transaction | Tx Broadcast | Instruct the node to broadcast the transcation to the network. |

--- a/content/_guides/offline_tx_signing.md
+++ b/content/_guides/offline_tx_signing.md
@@ -17,7 +17,7 @@ Transactions are constructed using the view-only wallet on the online device, th
 Feather supports two airgapped transaction signing methods:
 
 - Using a webcam to scan **animated QR code** (Uniform Resources, or **UR** for short)
-- By transfering **files** between computers (using a flash drive or SD card) 
+- By transferring **files** between computers (using a flash drive or SD card)
 
 For this guide we assume you will be using animated QR codes.
 

--- a/content/_guides/seed_scheme.md
+++ b/content/_guides/seed_scheme.md
@@ -27,7 +27,7 @@ Polyseed has a number of advantages over Monero's standard seeds:
 | French                | ✔                 | ✔                |
 | Italian               | ✔                 | ✔                |
 | Czech                 | ✔                 | ✖                |
-| Portugese             | ✔                 | ✖                |
+| Portuguese            | ✔                 | ✖                |
 | Dutch                 | ✖                 | ✔                |
 | Esperanto             | ✖                 | ✔                |
 | German                | ✖                 | ✔                |

--- a/content/_guides/tor_support.md
+++ b/content/_guides/tor_support.md
@@ -13,7 +13,7 @@ If you are unable to connect to the Tor network on your machine, you may configu
 Feather can be configured to handle traffic to nodes in three different ways:
 
 - Never over Tor
-- Switch to Tor after intial synchronization (**default**)
+- Switch to Tor after initial synchronization (**default**)
 - Always over Tor
 
 You have the option to select the desired mode when Feather is started for the first time **before** any network connections are made. You can also change the mode in the **Settings → Network → Proxy** tab.


### PR DESCRIPTION
While working on the Debian package, I noticed these typos in the documentation.